### PR TITLE
Changes made for browsing in browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ elasticpypi/config.json
 
 yarn.lock
 package-lock.json
+venv/

--- a/readme.md
+++ b/readme.md
@@ -5,9 +5,9 @@ A fully functional, self-hosted  simple pypi service running on AWS.
 
 # Caveats
 
-**Cannot browse with a browser**
+**Browse with a browser**
 
-This is a limitation of current browsers. They have removed basic authentication for remote urls via the url (e.g. x:y@z). `WWW-Authenticate` responses do not work with AWS Lambda.
+This is a limitation of current browsers. They have removed basic authentication for remote urls via the url (e.g. x:y@z). However, if you visit the URL directly, browser will promote you to enter username and password, or you can install this [plugin](https://chrome.google.com/webstore/detail/multipass-for-http-basic/enhldmjbphoeibbpdhmjkchohnidgnah) for Chrome and setup the credentials accordingly.
 
 **Uploads through the api are limited to 6MB**
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -39,6 +39,8 @@ functions:
           integration: lambda-proxy
           authorizer:
             name: authorizer
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
             type: request
       - http:
           path: simple
@@ -46,6 +48,8 @@ functions:
           integration: lambda-proxy
           authorizer:
             name: authorizer
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
             type: request
       - http:
           path: simple/{name}
@@ -53,6 +57,8 @@ functions:
           integration: lambda-proxy
           authorizer:
             name: authorizer
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
             type: request
   s3:
     handler: elasticpypi.handler.s3
@@ -79,6 +85,15 @@ custom:
 
 resources:
   Resources:
+    GatewayResponse:
+      Type: 'AWS::ApiGateway::GatewayResponse'
+      Properties:
+        ResponseParameters:
+          gatewayresponse.header.WWW-Authenticate: "'Basic'"
+        ResponseType: UNAUTHORIZED
+        RestApiId:
+          Ref: 'ApiGatewayRestApi'
+        StatusCode: '401'
     packagesTable:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
Thanks for this project. It is really useful. I added this small change, and it works great, so just want to contribute it back. Got the idea from https://medium.com/@Da_vidgf/http-basic-auth-with-api-gateway-and-serverless-5ae14ad0a270

Add WWW-Authenticate response header to API Gateway for UNAUTHORIZED requests, so URLs can be browsed in browsers.

Tested in pip, Chrome and Firefox

![new project](https://user-images.githubusercontent.com/1109028/48289639-0d212900-e425-11e8-85a4-884481b0368a.png)
