### PR TITLE
Allow for mixed case Authorization header

### DIFF
--- a/elasticpypi/handler.py
+++ b/elasticpypi/handler.py
@@ -23,7 +23,13 @@ def s3(event, context):
 
 
 def auth(event, context):
-    user, pwd = decode(event['headers']['Authorization'])
+    authorization_header = {k.lower(): v for k, v in event['headers'].items() if k.lower() == 'authorization'}
+    #log.debug("authorization: " + json.dumps(authorization_header))
+
+    # Get the username:password hash from the authorization header
+    username_password_hash = authorization_header['authorization'].split()[1]
+
+    user, pwd = decode(username_password_hash)
     if config.get('username') and config.get('password'):
         users = {config.get('username'): config.get('password')}
     if config.get('users'):


### PR DESCRIPTION
HTTP/2 requires that all headers be lower-case. This commit allows for any mixed case in the Authentication header.