### PR TITLE
Pin markupsafe==2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==1.1.4
 basicauth==0.4.1
+markupsafe==2.0.1


### PR DESCRIPTION
I was getting errors like "from markupsafe import soft_unicode / ImportError: cannot import name 'soft_unicode' "

Pinning markupsafe back to 2.0.1 resolves this issue.  Perhaps bumping Flask or basicauth also resolves this issue, but I didn't go down that road.
 

